### PR TITLE
build(deps): bump golang.org/x/image from 0.38.0 to 0.39.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require github.com/vdobler/chart v1.0.0
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/llgcode/draw2d v0.0.0-20260213073409-1c39bbefe083 // indirect
-	golang.org/x/image v0.38.0 // indirect
+	golang.org/x/image v0.39.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,5 +14,5 @@ github.com/vdobler/chart v1.0.0 h1:ySWmgHJtBsb7/SItvKb+VM3Nxb0SksDIjZhSbiK+Wi0=
 github.com/vdobler/chart v1.0.0/go.mod h1:gRwLtqIJLDw1CkK9kxJXv3X9OaMfM4dYsbZtWtVLxvM=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20181030002151-69cc3646b96e/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
-golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
-golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
+golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=


### PR DESCRIPTION
Resolves CVE-2026-33809 by upgrading golang.org/x/image to 0.39.0.

---
*PR created automatically by Jules for task [2279512160606371611](https://jules.google.com/task/2279512160606371611) started by @arran4*